### PR TITLE
Add support for JSON RPC v2.0 Authentication Extension

### DIFF
--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -21,7 +21,7 @@ class Controller extends \yii\web\Controller
     ];
 
     /** @var \stdClass Contains parsed JSON-RPC 2.0 request object*/
-    private $requestObject;
+    protected $requestObject;
 
     /**
      * Validates, runs Action and returns result in JSON-RPC 2.0 format

--- a/JsonRpc2/extensions/AuthException.php
+++ b/JsonRpc2/extensions/AuthException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JsonRpc2\extensions;
+
+/**
+ * An extension of \JsonRpc2\Exception with additional error codes defined
+ * by the JSON RPC v2.0 Authentication Extension.
+ * 
+ * @see https://jsonrpcx.org/AuthX/HomePage
+ * 
+ * @author Tyler Ham <tyler@thamtech.com>
+ */
+class AuthException extends \JsonRpc2\Exception
+{
+    const MISSING_AUTH = -32651;
+    const INVALID_AUTH = -32652;
+    
+    public function __construct($message, $code, $data = null)
+    {
+        parent::__construct($message, $code, $data);
+    }
+}

--- a/JsonRpc2/extensions/AuthTrait.php
+++ b/JsonRpc2/extensions/AuthTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace JsonRpc2\extensions;
+
+/**
+ * Provides access to the JSON-RPC 2.0 request object's auth member
+ * as described by the JSON RPC v2.0 Authentication Extension.
+ * 
+ * @see https://jsonrpcx.org/AuthX/HomePage
+ * 
+ * @author Tyler Ham <tyler@thamtech.com>
+ */
+trait AuthTrait
+{
+    
+    /**
+     * Gets the auth credentials passed in the JSON-RPC 2.0 request object.
+     * 
+     * @return mixed the auth credentials or null if the auth member was not provided.
+     */
+    public function getAuthCredentials() {
+        return isset($this->requestObject->auth) ? $this->requestObject->auth : null;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,55 @@ Easiest way to use in 4 steps:<br/>
 
 <br/>
 
+###Authentication Extension
+If you would like to use the [JSON RPC v2.0 Authentication Extension](https://jsonrpcx.org/AuthX/HomePage),
+you may use the \JsonRpc2\extensions\AuthTrait in your instance of
+\JsonRpc2\Controller like
+
+~~~php
+class ServicesController extends \JsonRpc2\Controller
+{
+    use \JsonRpc2\extensions\AuthTrait;
+}
+~~~
+
+Then, you can make a request with an auth token like
+
+~~~javascript
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "whoami",
+    "auth": "some_access_token"
+}
+~~~
+
+Finally, in a [Filter](http://www.yiiframework.com/doc-2.0/guide-structure-filters.html)
+or in your action method, you can call the getAuthCredentials() to get the value
+of the "auth" member of the request object like
+
+~~~php
+public function actionWhoami($message)
+{
+    $user = User::findIdentityByAccessToken($this->getAuthCredentials());
+    if (!$user) {
+        throw new \JsonRpc2\extensions\AuthException('Missing auth',
+            \JsonRpc2\extensions\AuthException::MISSING_AUTH);
+    }
+    
+    return ['uid' => $user->id];
+}
+~~~
+
+The nature of the "auth" value and how your User identity class will use it to
+findIdentityByAccessToken is application specific. For example, in simple
+scenarios when each user can only have one access token, you may store the
+access token in an access_token column in the user table. See the Yii
+[REST Authentication](http://www.yiiframework.com/doc-2.0/guide-rest-authentication.html)
+documentation for related information.
+
+<br/>
+
 ###Params validation
 For validation params data you MUST create [phpDoc @param](http://manual.phpdoc.org/HTMLSmartyConverter/PHP/phpDocumentor/tutorial_tags.param.pkg.html) tags comments with type to action method.<br/>
 After that param data will be converted to documented type.


### PR DESCRIPTION
- Change visibility of $requestObject from private to protected
- Add AuthException with error codes defined by the Authentication Extension
- Add AuthTrait to provide a way for Controller and Filter methods to access the "auth" credentials in the request object
