### PR TITLE
Maintain headers set in Yii's Response object

### DIFF
--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -54,7 +54,7 @@ class Controller extends \yii\web\Controller
             }
         }
 
-        $response = new Response();
+        $response = Yii::$app->getResponse();
         $response->format = Response::FORMAT_JSON;
         $response->data = $isBatch || null === $resultData ? $resultData : current($resultData);
         return $response;


### PR DESCRIPTION
I ran into a little trouble trying to enable the [Cors](http://www.yiiframework.com/doc-2.0/yii-filters-cors.html) filter. It sets headers in the `Yii:$app->getResponse()` object, but the `runAction()` method would return an entirely new Response object, so the response headers would be lost.

With this commit, we just set the `format` and `data` properties of the existing Response object and return it.

I think this is a relatively simple fix, but if there was a reason a new Response object was being created, then we should discuss it before merging this in, since there might be a better solution (like copying over headers from the existing Response object).
