### PR TITLE
Docblock parser fixes

### DIFF
--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -316,12 +316,12 @@ class Controller extends \yii\web\Controller
 
         $lines = preg_split ('/$\R?^/m', $method->getDocComment());
         for ($i=0; $i<count($lines); $i++) {
-            preg_match("/@param $variableRegex ([\w\\\\\[\]]+)/", $lines[$i], $paramMatches);
+            preg_match("/@param ([\w\\\\\[\]]+) $variableRegex/", $lines[$i], $paramMatches);
             if (!empty($paramMatches)) {
-                $subject = &$this->methodInfo['params'][$paramMatches[1]];
+                $subject = &$this->methodInfo['params'][$paramMatches[2]];
                 $subject = $infoTpl;
-                $subject['name'] = $paramMatches[1];
-                $subject['type'] = $paramMatches[2];
+                $subject['name'] = $paramMatches[2];
+                $subject['type'] = $paramMatches[1];
             } else {
                 preg_match("/@return ([\w\\\\\[\]]+)/", $lines[$i], $paramMatches);
                 if (!empty($paramMatches)) {

--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -316,14 +316,14 @@ class Controller extends \yii\web\Controller
 
         $lines = preg_split ('/$\R?^/m', $method->getDocComment());
         for ($i=0; $i<count($lines); $i++) {
-            preg_match("/@param ([\w\\\\\[\]]+) $variableRegex/", $lines[$i], $paramMatches);
+            preg_match("/@param\s+([\w\\\\\[\]]+)\s+$variableRegex/", $lines[$i], $paramMatches);
             if (!empty($paramMatches)) {
                 $subject = &$this->methodInfo['params'][$paramMatches[2]];
                 $subject = $infoTpl;
                 $subject['name'] = $paramMatches[2];
                 $subject['type'] = $paramMatches[1];
             } else {
-                preg_match("/@return ([\w\\\\\[\]]+)/", $lines[$i], $paramMatches);
+                preg_match("/@return\s+([\w\\\\\[\]]+)/", $lines[$i], $paramMatches);
                 if (!empty($paramMatches)) {
                     $subject = &$this->methodInfo['return'];
                     $subject = $infoTpl;

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ But we can receive params as associative object and in this case param's order i
 Let's validate **$message** as int value in our **actionUpdate** and increase it:
 ~~~php
 /**
- * @param $message int
+ * @param int $message
  * @return array
  */
 public function actionUpdate($message)
@@ -195,7 +195,7 @@ class Test extends Dto {
 ...and change **actionUpdate** for using Test DTO
 ~~~php
 /**
- * @param $test \JsonRpc2\Dto\Test
+ * @param \JsonRpc2\Dto\Test $test
  * @return array
  */
 public function actionUpdate($test)
@@ -223,8 +223,8 @@ You can use this arrays in actions OR in DTOs and all params data will be valida
 **'Update'** Action:
 ~~~php
 /**
- * @param $tests \JsonRpc2\Dto\Test[]
- * @param $messages string[]
+ * @param \JsonRpc2\Dto\Test[] $tests
+ * @param string[] $messages
  * @return array
  */
 public function actionUpdate($tests, $messages)


### PR DESCRIPTION
- Fix the order of @param type and variable name in phpDoc parser and README
- Allow @param and @return docblock lines more flexibility with whitespace characters (the regular expresion previously required exactly 1 space character between fields, but now it allows any number of spaces)

See the commit messages for more details.
