### PR TITLE
Add a "light" method protocol option to support specifying the method in the URL

### DIFF
--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -49,7 +49,7 @@ class Controller extends \yii\web\Controller
             $resultData = [Helper::formatResponse(null, new Exception("Invalid Request", Exception::INVALID_REQUEST))];
         } else {
             foreach ($requests as $request) {
-                if($response = $this->getActionResponse($request))
+                if($response = $this->getActionResponse($request, $id))
                     $resultData[] = $response;
             }
         }
@@ -67,11 +67,11 @@ class Controller extends \yii\web\Controller
      * @throws \yii\web\HttpException
      * @return Response
      */
-    private function getActionResponse($requestObject)
+    private function getActionResponse($requestObject, $id)
     {
         $this->requestObject = $result = $error = null;
         try {
-            $this->parseAndValidateRequestObject($requestObject);
+            $this->parseAndValidateRequestObject($requestObject, $id);
             ob_start();
             $dirtyResult = parent::runAction($this->requestObject->method);
             ob_clean();
@@ -178,7 +178,7 @@ class Controller extends \yii\web\Controller
      * Request has to be sent as POST and with Content-type: application/json
      * @throws \yii\web\HttpException
      */
-    private function initRequest($id)
+    protected function initRequest($id)
     {
         list($contentType) = explode(";", Yii::$app->request->getContentType()); //cut charset
         if (!empty($id) || !Yii::$app->request->getIsPost() || empty($contentType) || $contentType != "application/json")
@@ -190,7 +190,7 @@ class Controller extends \yii\web\Controller
      * @param $requestObject string
      * @throws Exception
      */
-    private function parseAndValidateRequestObject($requestObject)
+    protected function parseAndValidateRequestObject($requestObject, $id)
     {
         if (null === $requestObject)
             throw new Exception("Parse error", Exception::PARSE_ERROR);

--- a/JsonRpc2/LightMethodProtocolTrait.php
+++ b/JsonRpc2/LightMethodProtocolTrait.php
@@ -21,7 +21,7 @@ namespace JsonRpc2;
  *     "jsonrpc": "2.0",
  *     "id": 1,
  *     "method": "update",
- *     "params": ["world"}]
+ *     "params": ["world"]
  * }
  * ```
  * 
@@ -34,7 +34,7 @@ namespace JsonRpc2;
  * {
  *     "jsonrpc": "2.0",
  *     "id": 1,
- *     "params": ["world"}]
+ *     "params": ["world"]
  * }
  * ```
  * 

--- a/JsonRpc2/LightMethodProtocolTrait.php
+++ b/JsonRpc2/LightMethodProtocolTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace JsonRpc2;
+
+/**
+ * Adds support in a [[Controller]] for a "light" method protocol that allows
+ * clients to encode the method name in the URL instead of in the "method"
+ * parameter of the request object.
+ * 
+ * One advantage of the light method format is that web server access logs will
+ * contain the method invoked, because it is in the URL. The standard "heavy"
+ * format will not, because the method is inside the POST data.
+ * 
+ * Without the LightMethodProtocol, a client would post to
+ * ```
+ * http://yoursite/services
+ * ```
+ * with data
+ * ```javascript
+ * {
+ *     "jsonrpc": "2.0",
+ *     "id": 1,
+ *     "method": "update",
+ *     "params": ["world"}]
+ * }
+ * ```
+ * 
+ * However, with the LightMethodProtocol, a client could instead post to
+ * ```
+ * http://yoursite/services/update
+ * ```
+ * with data
+ * ```javascript
+ * {
+ *     "jsonrpc": "2.0",
+ *     "id": 1,
+ *     "params": ["world"}]
+ * }
+ * ```
+ * 
+ * The method may be specified both in the URL and in the request object
+ * provided that they match.  If the method is specified in both places, an
+ * error is thrown if they do not match.
+ * 
+ * @author Tyler Ham <tyler@thamtech.com>
+ */
+trait LightMethodProtocolTrait
+{
+    /**
+     * @inheritdoc
+     */
+    protected function initRequest($id)
+    {
+        // parent will throw an exception if $id is non-empty, but we want to
+        // allow a non-empty $id in Light-mode
+        parent::initRequest('');
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    protected function parseAndValidateRequestObject($requestObject, $id)
+    {
+        if ($requestObject !== null)
+        {
+            // if method is specified both in the URL and in the $id, and
+            // they do not match, we throw an error
+            if (!empty($requestObject->method) && !empty($id) && $requestObject->method != $id)
+            {
+                throw new Exception("Invalid Request - method mismatch", Exception::INVALID_REQUEST);
+            }
+            
+            // if the $requestObject method is not specified or isn't a string,
+            // use the $id from the URL instead
+            if ((empty($requestObject->method) || "string" != gettype($requestObject->method)) && !empty($id))
+            {
+                $requestObject->method = $id;
+            }
+        }
+        
+        parent::parseAndValidateRequestObject($requestObject, '');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -112,6 +112,56 @@ documentation for related information.
 
 <br/>
 
+###Light Method Protocol
+If you wish, you may uuse a "light" method protocol that allows clients to
+encode the method name in the URL instead of in the "method" parameter of the
+request object. To do this, use the \JsonRpc2\LightMethodProtocolTrait in your
+instance of \JsonRpc2\Controller like
+
+~~~php
+class ServicesController extends \JsonRpc2\Controller
+{
+    use \JsonRpc2\LightMethodProtocolTrait;
+}
+~~~
+
+One advantage of the light method format is that web server access logs will
+contain the method invoked, because it is in the URL. The standard "heavy"
+format will not, because the method is inside the POST data.
+
+Without the LightMethodProtocol, a client would post to
+```
+http://yoursite/services
+```
+with data
+```javascript
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "update",
+    "params": ["world"}]
+}
+```
+
+However, with the LightMethodProtocol, a client could instead post to
+```
+http://yoursite/services/update
+```
+with data
+```javascript
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "params": ["world"}]
+}
+```
+
+The method may be specified both in the URL and in the request object
+provided that they match.  If the method is specified in both places, an
+error is thrown if they do not match.
+
+<br/>
+
 ###Params validation
 For validation params data you MUST create [phpDoc @param](http://manual.phpdoc.org/HTMLSmartyConverter/PHP/phpDocumentor/tutorial_tags.param.pkg.html) tags comments with type to action method.<br/>
 After that param data will be converted to documented type.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ documentation for related information.
 <br/>
 
 ###Light Method Protocol
-If you wish, you may uuse a "light" method protocol that allows clients to
+If you wish, you may use a "light" method protocol that allows clients to
 encode the method name in the URL instead of in the "method" parameter of the
 request object. To do this, use the \JsonRpc2\LightMethodProtocolTrait in your
 instance of \JsonRpc2\Controller like
@@ -139,7 +139,7 @@ with data
     "jsonrpc": "2.0",
     "id": 1,
     "method": "update",
-    "params": ["world"}]
+    "params": ["world"]
 }
 ```
 
@@ -152,7 +152,7 @@ with data
 {
     "jsonrpc": "2.0",
     "id": 1,
-    "params": ["world"}]
+    "params": ["world"]
 }
 ```
 


### PR DESCRIPTION
With the "light" method protocol, clients can encode the method name in the URL like `<controller>/<action>` instead of calling `<controller>` and including the method in the JSON RPC request body.

One advantage of the light method format is that web server access logs will contain the method invoked because it is in the URL. The standard "heavy" format will not, because the method only appears inside the POST data.

The commit includes:
- minor adjustments to `Controller.php`,
- a new `LightMethodProtocolTrait.php` that a developer can import in their Controller to enable this alternate version of the protocol, and
- additional usage documentation in the README
