### PR TITLE
no need for before action on an empty action since we work thru json-rpc

### DIFF
--- a/JsonRpc2/Controller.php
+++ b/JsonRpc2/Controller.php
@@ -195,17 +195,6 @@ class Controller extends \yii\web\Controller
         ) {
             throw new HttpException(404, "Page not found");
         }
-
-        //Call beforeActions on modules and controller to run all filters in behaviors() methods
-        $action = parent::createAction('');
-        // call beforeAction on modules
-        foreach ($this->getModules() as $module) {
-            if (!$module->beforeAction($action)) {
-                break;
-            }
-        }
-        // call beforeAction on controller
-        $this->beforeAction($action);
     }
 
     /**


### PR DESCRIPTION
Now it works just like this
```php
<?php

namespace app\controllers;

use \JsonRpc2\Controller;
use app\components\JwtAccessControl;

class ApiController extends Controller
{
	/**
	* {@inheritdoc}
	*/
	public function behaviors()
	{
		return [
			'access' => [
				'class' => JwtAccessControl::className(),
				'except' => ['login'],
			],
		];
	}

	public function actionLogin() {
		return 'login';
	}

	public function actionUpdate() {
		return 'update';
	}
}
```
```php
<?php

namespace app\components;

use Yii;
use yii\base\ActionFilter;

class JwtAccessControl extends ActionFilter
{
  public function beforeAction($action)
  {
    if (true)
      throw new \JsonRpc2\extensions\AuthException('Missing auth', \JsonRpc2\extensions\AuthException::MISSING_AUTH);

    return parent::beforeAction($action);
  }

  public function afterAction($action, $result)
  {
    return parent::afterAction($action, $result);
  }
}
```